### PR TITLE
Improve documentation - simplify use when creating API Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,77 @@
 
 SCX Channel-API Client repository for JTL-Sales-Channel-Extension based on PHP. 
 
-## Example usage
+[Channel API Documentation](https://scx-sandbox.ui.jtl-software.com/docs/api_channel.html)
+
+## Usage
+
 ```php
-$client = new Client();
-$config = new Configuration('http://localhost', 'AUTHTOKEN');
+use JTL\SCX\Client\Api\AuthAwareApiClient;
+use JTL\SCX\Client\Api\Configuration;
+use JTL\SCX\Client\Channel\Api\Attribute\AttributesApi;
+use JTL\SCX\Client\Channel\Api\Category\CategoryApi;
+use JTL\SCX\Client\Channel\Api\Event\EventApi;
+use JTL\SCX\Client\Channel\Api\Offer\OfferApi;
+use JTL\SCX\Client\Channel\Api\Order\OrderApi;
+use JTL\SCX\Client\Channel\Api\Price\PriceApi;
+use JTL\SCX\Client\Channel\Api\Seller\SellerApi;
 
-$api = new CreateSellerAttributesApi($client, $config);
+$configuration = new Configuration(
+    Configuration::HOST_PRODUCTION,
+    $_ENV['refreshToken']
+);
 
-$attribute = new Attribute();
-$attribute->setAttributeId('ATTR001');
-$attribute->setDisplayName('Test Attribute');
+// AuthAwareApiClient will perform authentication stuff
+$client = new AuthAwareApiClient($configuration);
 
-$attributeList = new AttributeList();
-$attributeList->setAttributeList([$attribute]);
+// read and acknowledge seller events
+$eventApi = new EventApi($client);
 
-$request = new CreateSellerAttributesRequest('SELLER1', $attributeList);
-$api->createSellerAttributes($request);
+// manage sellers (create)
+$sellerApi = new SellerApi($client);
+
+// manage meta data such as Categories, Attributes or Price
+$attributesApi = new AttributesApi($client);
+$categoryApi = new CategoryApi($client);
+$priceApi = new PriceApi($client);
+
+// manage orders (send new orders, update order status or address information)
+$orderApi = new OrderApi($client);
+
+// manage offers (mark in progress, mark as listed, mark as listing failed)
+$offerApi = new OfferApi($client);
+```
+
+## Working with Events
+
+Seller events are one of the most important features in SCX-Channel-Api. A Seller Event
+is created by a Seller API Implementation, such as JTL-Wawi to request a action by the existing
+channel integration.
+
+See `JTL\SCX\Client\Channel\Event\EventType` for a list of existing Events.
+  
+
+```php
+$eventApi = new EventApi($authAwareApiClient);
+
+$sellerEventList = $eventApi->getEventList(new GetEventListRequest());
+foreach ($sellerEventList->getEventList() as $eventContainer) {
+
+    // The Id of the event use this id to acknowledge event after processing
+    $id = $eventContainer->getId();
+
+    // Datetime when the event was created
+    $createdAt = $eventContainer->getCreatedAt();
+
+    // The Event Type
+    $type = $eventContainer->getType();
+
+    // The Event itself
+    $eventModel = $eventContainer->getEvent();
+
+    // processEvent($eventContainer)
+
+    // finally acknowledge event after processing
+    $eventApi->ack(new AcknowledgeEventIdListRequest([$id]));
+}
 ```

--- a/src/Api/Category/CategoryApi.php
+++ b/src/Api/Category/CategoryApi.php
@@ -10,6 +10,7 @@ namespace JTL\SCX\Client\Channel\Api\Category;
 
 use GuzzleHttp\Exception\GuzzleException;
 use JTL\SCX\Client\Api\AuthAwareApiClient;
+use JTL\SCX\Client\ApiResponseDeserializer;
 use JTL\SCX\Client\Channel\Api\Category\Request\UpdateCategoryTreeRequest;
 use JTL\SCX\Client\Channel\Api\Category\Response\UpdateCategoryTreeResponse;
 use JTL\SCX\Client\Channel\Model\CategoryTreeVersion;
@@ -21,10 +22,12 @@ class CategoryApi
     private AuthAwareApiClient $apiClient;
     private ResponseDeserializer $responseDeserializer;
 
-    public function __construct(AuthAwareApiClient $apiClient, ResponseDeserializer $responseDeserializer)
-    {
+    public function __construct(
+        AuthAwareApiClient $apiClient,
+        ResponseDeserializer $responseDeserializer = null
+    ) {
         $this->apiClient = $apiClient;
-        $this->responseDeserializer = $responseDeserializer;
+        $this->responseDeserializer = $responseDeserializer ?? new ApiResponseDeserializer();
     }
 
     /**

--- a/src/Api/Channel/ChannelApi.php
+++ b/src/Api/Channel/ChannelApi.php
@@ -10,6 +10,7 @@ namespace JTL\SCX\Client\Channel\Api\Channel;
 
 use GuzzleHttp\Exception\GuzzleException;
 use JTL\SCX\Client\Api\AuthAwareApiClient;
+use JTL\SCX\Client\ApiResponseDeserializer;
 use JTL\SCX\Client\Channel\Api\Channel\Request\GetChannelStatusRequest;
 use JTL\SCX\Client\Channel\Api\Channel\Request\UpdateChannelRequest;
 use JTL\SCX\Client\Channel\Api\Channel\Response\GetChannelStatusResponse;
@@ -23,10 +24,12 @@ class ChannelApi
     private AuthAwareApiClient $client;
     private ResponseDeserializer $responseDeserializer;
 
-    public function __construct(AuthAwareApiClient $client, ResponseDeserializer $responseDeserializer)
-    {
+    public function __construct(
+        AuthAwareApiClient $client,
+        ResponseDeserializer $responseDeserializer = null
+    ) {
         $this->client = $client;
-        $this->responseDeserializer = $responseDeserializer;
+        $this->responseDeserializer = $responseDeserializer ?? new ApiResponseDeserializer();
     }
 
     /**

--- a/src/Api/Event/Model/EventContainer.php
+++ b/src/Api/Event/Model/EventContainer.php
@@ -8,6 +8,7 @@
 
 namespace JTL\SCX\Client\Channel\Api\Event\Model;
 
+use JTL\SCX\Client\Channel\Event\EventType;
 use JTL\SCX\Client\Channel\Model\SellerEventOfferEnd;
 use JTL\SCX\Client\Channel\Model\SellerEventOfferNew;
 use JTL\SCX\Client\Channel\Model\SellerEventOrderCancelled;
@@ -21,10 +22,10 @@ class EventContainer
 {
     private string $id;
     private \DateTimeImmutable $createdAt;
-    private string $type;
+    private EventType $type;
     private $event;
 
-    public function __construct(string $id, \DateTimeImmutable $createdAt, string $type, $event)
+    public function __construct(string $id, \DateTimeImmutable $createdAt, EventType $type, $event)
     {
         $this->id = $id;
         $this->createdAt = $createdAt;
@@ -42,7 +43,7 @@ class EventContainer
         return $this->createdAt;
     }
 
-    public function getType(): string
+    public function getType(): EventType
     {
         return $this->type;
     }

--- a/src/Api/Order/OrderApi.php
+++ b/src/Api/Order/OrderApi.php
@@ -10,11 +10,11 @@ namespace JTL\SCX\Client\Channel\Api\Order;
 
 use GuzzleHttp\Exception\GuzzleException;
 use JTL\SCX\Client\Api\AuthAwareApiClient;
-use JTL\SCX\Client\Channel\Api\Order\Request\CreateOrdersRequest;
+use JTL\SCX\Client\Channel\Api\Order\Request\CreateOrderRequest;
 use JTL\SCX\Client\Channel\Api\Order\Response\CreateOrdersResponse;
 use JTL\SCX\Client\Exception\RequestFailedException;
 
-class OrdersApi
+class OrderApi
 {
     private AuthAwareApiClient $client;
 
@@ -24,12 +24,12 @@ class OrdersApi
     }
 
     /**
-     * @param CreateOrdersRequest $request
+     * @param CreateOrderRequest $request
      * @return CreateOrdersResponse
      * @throws RequestFailedException
      * @throws GuzzleException
      */
-    public function create(CreateOrdersRequest $request): CreateOrdersResponse
+    public function create(CreateOrderRequest $request): CreateOrdersResponse
     {
         $response = $this->client->request($request);
 

--- a/src/Api/Order/Request/CreateOrderRequest.php
+++ b/src/Api/Order/Request/CreateOrderRequest.php
@@ -12,7 +12,7 @@ use JTL\SCX\Client\Channel\Api\AbstractScxApiRequest;
 use JTL\SCX\Client\Channel\Model\OrderList;
 use JTL\SCX\Client\Request\ScxApiRequest;
 
-class CreateOrdersRequest extends AbstractScxApiRequest
+class CreateOrderRequest extends AbstractScxApiRequest
 {
     private OrderList $orderList;
 

--- a/tests/Api/Event/Model/EventContainerTest.php
+++ b/tests/Api/Event/Model/EventContainerTest.php
@@ -9,6 +9,7 @@
 namespace JTL\SCX\Client\Channel\Api\Event\Model;
 
 use JTL\SCX\Client\Channel\AbstractTestCase;
+use JTL\SCX\Client\Channel\Event\EventType;
 use JTL\SCX\Client\Channel\Model\SellerEventOfferEnd;
 
 /**
@@ -23,7 +24,7 @@ class EventContainerTest extends AbstractTestCase
     {
         $id = uniqid('id', true);
         $createdAt = new \DateTimeImmutable();
-        $type = uniqid('type', true);
+        $type = $this->createStub(EventType::class);
         $event = $this->createStub(SellerEventOfferEnd::class);
 
         $eventContainer = new EventContainer($id, $createdAt, $type, $event);

--- a/tests/Api/Order/OrderApiTest.php
+++ b/tests/Api/Order/OrderApiTest.php
@@ -10,7 +10,7 @@ namespace JTL\SCX\Client\Channel\Api\Order;
 
 use JTL\SCX\Client\Api\AuthAwareApiClient;
 use JTL\SCX\Client\Channel\AbstractTestCase;
-use JTL\SCX\Client\Channel\Api\Order\Request\CreateOrdersRequest;
+use JTL\SCX\Client\Channel\Api\Order\Request\CreateOrderRequest;
 use JTL\SCX\Client\Channel\Api\Order\Response\CreateOrdersResponse;
 use Psr\Http\Message\ResponseInterface;
 
@@ -18,20 +18,20 @@ use Psr\Http\Message\ResponseInterface;
  * Class CreateOrdersApiTest
  * @package JTL\SCX\Client\Channel\Api\Order
  *
- * @covers \JTL\SCX\Client\Channel\Api\Order\OrdersApi
+ * @covers \JTL\SCX\Client\Channel\Api\Order\OrderApi
  */
-class OrdersApiTest extends AbstractTestCase
+class OrderApiTest extends AbstractTestCase
 {
     public function testCreate(): void
     {
-        $requestMock = $this->createMock(CreateOrdersRequest::class);
+        $requestMock = $this->createMock(CreateOrderRequest::class);
         $responseMock = $this->createMock(ResponseInterface::class);
         $responseMock->method('getStatusCode')->willReturn(200);
 
         $apiClientMock = $this->createMock(AuthAwareApiClient::class);
         $apiClientMock->expects($this->once())->method('request')->with($requestMock)->willReturn($responseMock);
 
-        $client = new OrdersApi($apiClientMock);
+        $client = new OrderApi($apiClientMock);
         $this->assertInstanceOf(CreateOrdersResponse::class, $client->create($requestMock));
     }
 }

--- a/tests/Api/Order/Request/CreateOrdersRequestTest.php
+++ b/tests/Api/Order/Request/CreateOrdersRequestTest.php
@@ -15,7 +15,7 @@ use JTL\SCX\Client\Channel\Model\OrderList;
  * Class CreateOrdersRequestTest
  * @package JTL\SCX\Client\Channel\Api\Order\Request
  *
- * @covers \JTL\SCX\Client\Channel\Api\Order\Request\CreateOrdersRequest
+ * @covers \JTL\SCX\Client\Channel\Api\Order\Request\CreateOrderRequest
  */
 class CreateOrdersRequestTest extends AbstractTestCase
 {
@@ -23,7 +23,7 @@ class CreateOrdersRequestTest extends AbstractTestCase
     {
         $orderList = $this->createMock(OrderList::class);
 
-        $request = new CreateOrdersRequest($orderList);
+        $request = new CreateOrderRequest($orderList);
 
         $this->assertSame($orderList, $request->getOrderList());
         $this->assertSame((string)$orderList, $request->getBody());


### PR DESCRIPTION
* add examples to README.md
* rename "Orders" to "Order"
* make requirements for Helper Objects optinal to simplify instance creation