### PR TITLE
EA-3807: Better event error handling

### DIFF
--- a/src/Api/Event/EventApi.php
+++ b/src/Api/Event/EventApi.php
@@ -11,6 +11,7 @@ namespace JTL\SCX\Client\Channel\Api\Event;
 use GuzzleHttp\Exception\GuzzleException;
 use JTL\SCX\Client\Api\AuthAwareApiClient;
 use JTL\SCX\Client\Channel\Api\ChannelApiResponseDeserializer;
+use JTL\SCX\Client\Channel\Api\Event\Model\ErroneousEvent;
 use JTL\SCX\Client\Channel\Api\Event\Model\EventContainer;
 use JTL\SCX\Client\Channel\Api\Event\Model\EventContainerList;
 use JTL\SCX\Client\Channel\Api\Event\Request\AcknowledgeEventIdListRequest;
@@ -46,24 +47,40 @@ class EventApi
     public function get(GetEventListRequest $request = null): GetSellerEventListResponse
     {
         $responseData = $this->client->request($request ?? new GetEventListRequest());
-        $data = $this->jsonSerializer->deserialize($responseData->getBody()->getContents(), false);
+        $data = $this->jsonSerializer->deserialize((string)$responseData->getBody(), false);
         $eventList = new EventContainerList();
 
-        foreach ($data->eventList as $event) {
-            $eventType = new EventType($event->type);
-
-            $eventData = is_array($event->event) ? null : $this->createEventByType($eventType, $event->event);
-            $eventContainer = new EventContainer(
-                $event->id,
-                new \DateTimeImmutable($event->createdAt),
-                $eventType,
-                $eventData
-            );
-
-            $eventList->add($eventContainer);
+        if (!isset($data->eventList)) {
+            throw new \UnexpectedValueException('Missing eventList property in Api Response');
         }
 
-        return new GetSellerEventListResponse($eventList, $responseData->getStatusCode());
+        $errorEvents = [];
+        foreach ($data->eventList as $event) {
+            if (!isset($event->type, $event->id, $event->event, $event->createdAt)) {
+                $eventJson = json_encode($event);
+                $errorEvents[] = new ErroneousEvent($eventJson, "Invalid or missing properties", null);
+                continue;
+            }
+
+            try {
+                $eventType = new EventType($event->type);
+                $eventData = is_array($event->event) ? null : $this->createEventByType($eventType, $event->event);
+
+                $eventContainer = new EventContainer(
+                    (string)$event->id,
+                    new \DateTimeImmutable($event->createdAt),
+                    $eventType,
+                    $eventData
+                );
+                $eventList->add($eventContainer);
+            } catch (\Throwable $exception) {
+                $eventJson = json_encode($event);
+                $errorEvents[] = new ErroneousEvent($eventJson, $exception->getMessage(), $exception);
+                continue;
+            }
+        }
+
+        return new GetSellerEventListResponse($eventList, $responseData->getStatusCode(), $errorEvents);
     }
 
     /**

--- a/src/Api/Event/Model/ErroneousEvent.php
+++ b/src/Api/Event/Model/ErroneousEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace JTL\SCX\Client\Channel\Api\Event\Model;
+
+class ErroneousEvent
+{
+    private ?\Throwable $exception;
+    private string $eventJson;
+    private string $errorMessage;
+
+    public function __construct(string $eventJson, string $errorMessage, ?\Throwable $exception)
+    {
+        $this->eventJson = $eventJson;
+        $this->errorMessage = $errorMessage;
+        $this->exception = $exception;
+    }
+
+    public function getException(): ?\Throwable
+    {
+        return $this->exception;
+    }
+
+    public function getEventJson(): string
+    {
+        return $this->eventJson;
+    }
+
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+
+
+}

--- a/src/Api/Event/Response/GetSellerEventListResponse.php
+++ b/src/Api/Event/Response/GetSellerEventListResponse.php
@@ -8,6 +8,7 @@
 
 namespace JTL\SCX\Client\Channel\Api\Event\Response;
 
+use JTL\SCX\Client\Channel\Api\Event\Model\ErroneousEvent;
 use JTL\SCX\Client\Channel\Api\Event\Model\EventContainerList;
 use JTL\SCX\Client\Response\AbstractResponse;
 
@@ -19,14 +20,21 @@ class GetSellerEventListResponse extends AbstractResponse
     private EventContainerList $eventList;
 
     /**
+     * @var array<ErroneousEvent>
+     */
+    private array $errorEvents;
+
+    /**
      * GetSellerEventListResponse constructor.
      * @param EventContainerList $eventList
      * @param int $statusCode
+     * @param array<ErroneousEvent> $errorEvents
      */
-    public function __construct(EventContainerList $eventList, int $statusCode)
+    public function __construct(EventContainerList $eventList, int $statusCode, array $errorEvents = [])
     {
-        $this->eventList = $eventList;
         parent::__construct($statusCode);
+        $this->eventList = $eventList;
+        $this->errorEvents = $errorEvents;
     }
 
     /**
@@ -35,5 +43,13 @@ class GetSellerEventListResponse extends AbstractResponse
     public function getEventList(): EventContainerList
     {
         return $this->eventList;
+    }
+
+    /**
+     * @return array<ErroneousEvent>
+     */
+    public function getErroneousEvents(): array
+    {
+        return $this->errorEvents;
     }
 }

--- a/tests/Api/Event/Model/ErroneousEventTest.php
+++ b/tests/Api/Event/Model/ErroneousEventTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace JTL\SCX\Client\Channel\Api\Event\Model;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JTL\SCX\Client\Channel\Api\Event\Model\ErroneousEvent
+ */
+class ErroneousEventTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_may_have_a_Exception_Instance(): void
+    {
+        $exception = new \Exception();
+        $sut = new ErroneousEvent('eg', 'al', $exception);
+        self::assertSame($exception, $sut->getException());
+
+        $sut = new ErroneousEvent('eg', 'al', null);
+        self::assertNull($sut->getException());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_affected_event_as_Json(): void
+    {
+        $eventJson = 'jsonString';
+        $sut = new ErroneousEvent($eventJson, 'wurscht', null);
+        self::assertSame($eventJson, $sut->getEventJson());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_error_message(): void
+    {
+        $errorMessage = 'THE_ERROR_MESSAGE';
+        $sut = new ErroneousEvent('jsonString', $errorMessage, null);
+        self::assertSame($errorMessage, $sut->getErrorMessage());
+    }
+
+
+}

--- a/tests/Api/Event/Response/GetSellerEventListResponseTest.php
+++ b/tests/Api/Event/Response/GetSellerEventListResponseTest.php
@@ -8,8 +8,9 @@
 
 namespace JTL\SCX\Client\Channel\Api\Event\Response;
 
-use PHPUnit\Framework\TestCase;
+use JTL\SCX\Client\Channel\Api\Event\Model\ErroneousEvent;
 use JTL\SCX\Client\Channel\Api\Event\Model\EventContainerList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class GetSellerEventListResponseTest
@@ -29,5 +30,20 @@ class GetSellerEventListResponseTest extends TestCase
 
         $this->assertSame($eventList, $response->getEventList());
         $this->assertSame($statusCode, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_may_have_a_list_of_ErroneousEvents(): void
+    {
+        $errorEvents = [$this->createStub(ErroneousEvent::class)];
+        $sut = new GetSellerEventListResponse(
+            $this->createStub(EventContainerList::class),
+            200,
+            $errorEvents
+        );
+
+        self::assertSame($errorEvents, $sut->getErroneousEvents());
     }
 }


### PR DESCRIPTION
Don't fail when one Event in the EventList can not be processed. Remember those events as erroneous and return them with the response object